### PR TITLE
Reduce multiple modifiers with OR instead of AND

### DIFF
--- a/zero_hid/keyboard.py
+++ b/zero_hid/keyboard.py
@@ -70,7 +70,7 @@ class Keyboard:
             if len(mods) == 1:
                 mods = mods[0]
             else:
-                mods = reduce(operator.and_, mods, 0)
+                mods = reduce(operator.or_, mods, 0)
             send_keystroke(self.dev, mods, keys[0])
             sleep(delay)
 
@@ -78,7 +78,7 @@ class Keyboard:
         if len(mods) == 1:
             mods = mods[0]
         else:
-            mods = reduce(operator.and_, mods, 0)
+            mods = reduce(operator.or_, mods, 0)
         send_keystroke(self.dev, mods, key_code, release=release)
 
     def release(self):


### PR DESCRIPTION
Modifier keys have a single bit set. When you want to send a modifier combination, you should bitwise OR the KeyCodes instead of AND, to write the relevant bits to the file descriptor. 

[Reference](https://stackoverflow.com/questions/66671427/multiple-modifiers-2-in-keyboard-input-report-for-custom-hid-keyboard)

Fixes #32 